### PR TITLE
Better `resolve_flavor behavior` and added tests

### DIFF
--- a/src/regex_toolkit/utils.py
+++ b/src/regex_toolkit/utils.py
@@ -27,39 +27,23 @@ __all__ = [
 SORT_BY_LEN_AND_ALPHA_KEY: Callable[[str], tuple[int, str]] = lambda x: (-len(x), x)
 
 
-def resolve_flavor(potential_flavor: int | RegexFlavor | None) -> RegexFlavor:
-    """Resolve a regex flavor.
-
-    If the flavor is an integer, it is validated and returned.
-    If the flavor is a RegexFlavor, it is returned.
-    If the flavor is None, the default flavor is returned. To change the default flavor, set `default_flavor`.
-
-    ```python
-    import regex_toolkit as rtk
-
-    rtk.base.default_flavor = 2
-    assert rtk.utils.resolve_flavor(None) == rtk.enums.RegexFlavor.RE2
-    ```
-
-    Args:
-        potential_flavor (int | RegexFlavor | None): Potential regex flavor.
-
-    Returns:
-        RegexFlavor: Resolved regex flavor.
-
-    Raises:
-        ValueError: Invalid regex flavor.
-    """
-    try:
-        return RegexFlavor(potential_flavor)
-    except ValueError as err:
-        if regex_toolkit.base.default_flavor is not None:
-            try:
-                return RegexFlavor(regex_toolkit.base.default_flavor)
-            except ValueError as err:
-                raise ValueError(f"Invalid regex flavor: {potential_flavor}") from err
-        else:
-            raise ValueError(f"Invalid regex flavor: {potential_flavor}") from err
+def resolve_flavor(flavor: int | RegexFlavor | None) -> RegexFlavor:
+    if flavor is not None:
+        try:
+            return RegexFlavor(flavor)
+        except ValueError:
+            raise ValueError(
+                f"Invalid regex flavor: {flavor!r}. Valid flavors are: {[f.value for f in ALL_REGEX_FLAVORS]}."
+            )
+    elif regex_toolkit.base.default_flavor is not None:
+        try:
+            return RegexFlavor(regex_toolkit.base.default_flavor)
+        except ValueError:
+            raise ValueError(
+                f"Invalid default regex flavor: {regex_toolkit.base.default_flavor!r}. Valid flavors are: {[f.value for f in ALL_REGEX_FLAVORS]}."
+            )
+    else:
+        raise ValueError("No regex flavor provided and no default is set.")
 
 
 def iter_sort_by_len_and_alpha(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,50 @@ def test_default_flavor_can_be_set():
     assert regex_toolkit.base.resolve_flavor(None) == RegexFlavor.RE2
 
 
+@pytest.mark.parametrize("flavor", INVALID_REGEX_FLAVORS)
+def test_resolve_flavor_invalid_int_raises(flavor):
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid regex flavor: .+\. Valid flavors are: \[\-?\d+(, \-?\d+)*\]\.$",
+    ):
+        regex_toolkit.base.resolve_flavor(flavor)
+
+
+def test_resolve_flavor_invalid_type_raises():
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid regex flavor: .+\. Valid flavors are: \[\-?\d+(, \-?\d+)*\]\.$",
+    ):
+        regex_toolkit.base.resolve_flavor(["not", "a", "flavor"])
+
+
+@pytest.mark.parametrize("flavor", INVALID_REGEX_FLAVORS)
+def test_resolve_flavor_None_with_invalid_int_default_raises(flavor):
+    regex_toolkit.base.default_flavor = flavor
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid default regex flavor: .+\. Valid flavors are: \[\-?\d+(, \-?\d+)*\]\.$",
+    ):
+        regex_toolkit.base.resolve_flavor(None)
+
+
+@mock.patch("regex_toolkit.base.default_flavor", ["not", "a", "flavor"])
+def test_resolve_flavor_None_with_invalid_type_default_raises():
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid default regex flavor: .+\. Valid flavors are: \[\-?\d+(, \-?\d+)*\]\.$",
+    ):
+        regex_toolkit.base.resolve_flavor(None)
+
+
+@mock.patch("regex_toolkit.base.default_flavor", None)
+def test_resolve_flavor_None_without_default_raises():
+    with pytest.raises(
+        ValueError, match=r"^No regex flavor provided and no default is set\.$"
+    ):
+        regex_toolkit.base.resolve_flavor(None)
+
+
 def is_sorted_by_length_and_alphabetically(
     texts: Iterable[str],
     reverse: bool = False,


### PR DESCRIPTION
* `resolve_flavor` will now raise an error if the provided regex flavor is invalid instead of falling back to the default.
* Added tests.